### PR TITLE
Refactor into modular async GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # uhalis
+
+This project provides a text moderation tool that evaluates the aggressiveness of social media posts. The application uses OpenAI's GPT models and presents a customtkinter based GUI.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install openai pandas customtkinter
+   ```
+2. Set your OpenAI API key in the `OPENAI_API_KEY` environment variable.
+3. Run the application:
+   ```bash
+   python main.py
+   ```
+
+The UI allows you to load an Excel file, select the column to analyze, and start moderation. You can adjust parameters and weight settings in the **設定** tab. Results can be saved back to an Excel file.

--- a/analyzer.py
+++ b/analyzer.py
@@ -1,0 +1,85 @@
+import asyncio
+from openai import AsyncOpenAI
+from config import MODEL_NAME
+
+class TextAnalyzer:
+    def __init__(self, client: AsyncOpenAI):
+        self.client = client
+
+    async def moderate_text(self, text: str):
+        resp = await self.client.moderations.create(
+            input=text,
+            model="omni-moderation-latest",
+        )
+        cats = resp.results[0].categories
+        scores = resp.results[0].category_scores
+        return cats, scores
+
+    async def get_aggressiveness_score(
+        self,
+        text: str,
+        temperature: float = 1.0,
+        top_p: float = 0.9,
+        max_retries: int = 3,
+    ):
+        prompt = f"""
+あなたソーシャルメディアの投稿を分析し、その攻撃性を評価する専門家です。
+以下の評価基準と例を参考に、与えられた文章の攻撃性スコアを0から9の整数で決定し、
+その理由を40〜60文字で簡潔に説明してください。
+
+# 評価基準:
+- 0: 攻撃性なし。中立的で誰に対しても敵意が感じられない。
+- 1-2: 非常に軽度の攻撃性。配慮に欠ける表現だが、攻撃意図が明確ではない。
+- 3-4: 軽度の攻撃性。間接的な批判や皮肉が含まれている。
+- 5-6: 中程度の攻撃性。明確な批判や侮辱的な表現が見られる。
+- 7-8: 高度の攻撃性。強い侮辱や敵意を伴う表現。
+- 9: 極度の攻撃性。暴力的な脅迫や人権侵害を伴うような非常に攻撃的な内容。
+
+# 評価例:
+---
+- 文章: "この映画、正直言って時間の無駄だったな。"
+- スコア: 3
+- 理由: 個人的な感想だが、作品を否定するやや強い表現が使われているため。
+---
+- 文章: "新製品の発表会、楽しみにしてます！応援してます！"
+- スコア: 0
+- 理由: 攻撃的な要素はなく、ポジティブで応援する内容であるため。
+---
+- 文章: "あいつのせいで全部台無しだ。絶対に許さない。"
+- スコア: 8
+- 理由: 特定の個人への強い敵意と攻撃的な言葉が明確に含まれているため。
+---
+
+# 分析対象の文章:
+{text}
+
+# 回答形式:
+スコア: [0-9の整数]
+理由: [40-60文字での具体的な理由]
+"""
+        for _ in range(max_retries):
+            try:
+                resp = await self.client.chat.completions.create(
+                    model=MODEL_NAME,
+                    messages=[
+                        {"role": "system", "content": "You analyze text and rate aggressiveness."},
+                        {"role": "user", "content": prompt},
+                    ],
+                    temperature=temperature,
+                    top_p=top_p,
+                )
+                content = resp.choices[0].message.content.strip()
+                score = None
+                reason = None
+                for line in content.split("\n"):
+                    if line.startswith("スコア"):
+                        val = line.split(":", 1)[1].strip()
+                        if val.isdigit():
+                            score = int(val)
+                    elif line.startswith("理由"):
+                        reason = line.split(":", 1)[1].strip()
+                if score is not None and reason:
+                    return score, reason
+            except Exception:
+                await asyncio.sleep(1)
+        return None, None

--- a/config.py
+++ b/config.py
@@ -1,0 +1,43 @@
+import json
+import os
+
+CONFIG_FILE = 'config.json'
+MODEL_NAME = "gpt-4.1-mini-2025-04-14"
+
+DEFAULT_WEIGHTS = {
+    "hate_score": 0.5,
+    "hate/threatening_score": 0.3,
+    "violence_score": 0.3,
+    "sexual_score": 0.1,
+    "sexual/minors_score": 0.1,
+    "aggressiveness_score": 0.5,
+    "flag_hate": 2.0,
+    "flag_hate/threatening": 1.0,
+    "flag_violence": 1.5,
+    "flag_sexual": 1.0
+}
+
+class ConfigManager:
+    def __init__(self, path: str = CONFIG_FILE):
+        self.path = path
+        self.data: dict = {}
+        self.load()
+
+    def load(self):
+        if os.path.exists(self.path):
+            with open(self.path, 'r', encoding='utf-8') as f:
+                self.data = json.load(f)
+        else:
+            self.data = {"weights": DEFAULT_WEIGHTS.copy()}
+
+    def save(self):
+        with open(self.path, 'w', encoding='utf-8') as f:
+            json.dump(self.data, f, ensure_ascii=False, indent=2)
+
+    def get_weight(self, key: str) -> float:
+        return self.data.get("weights", {}).get(key, DEFAULT_WEIGHTS.get(key, 0.0))
+
+    def set_weight(self, key: str, value: float):
+        if "weights" not in self.data:
+            self.data["weights"] = {}
+        self.data["weights"][key] = value

--- a/main.py
+++ b/main.py
@@ -1,0 +1,20 @@
+import os
+from openai import AsyncOpenAI
+
+from config import ConfigManager
+from analyzer import TextAnalyzer
+from ui import ModerationApp
+
+
+def main():
+    config = ConfigManager()
+    client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    if client.api_key is None:
+        raise ValueError("OpenAI APIキーが設定されていません。環境変数 'OPENAI_API_KEY' を設定してください。")
+    analyzer = TextAnalyzer(client)
+    app = ModerationApp(analyzer, config)
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/ui.py
+++ b/ui.py
@@ -1,0 +1,175 @@
+import asyncio
+import threading
+import pandas as pd
+import customtkinter as ctk
+from tkinter import filedialog, messagebox
+
+from analyzer import TextAnalyzer
+from config import ConfigManager
+
+ctk.set_appearance_mode("dark")
+ctk.set_default_color_theme("blue")
+
+class ModerationApp(ctk.CTk):
+    def __init__(self, analyzer: TextAnalyzer, config: ConfigManager):
+        super().__init__()
+        self.analyzer = analyzer
+        self.config = config
+        self.df = None
+        self.temperature = 1.0
+        self.top_p = 0.9
+        self.weights = config.data.get("weights", {})
+        self.create_ui()
+
+    def create_ui(self):
+        self.title("テキストモデレーションツール")
+        self.geometry("800x600")
+
+        self.tabview = ctk.CTkTabview(self)
+        self.tabview.pack(fill="both", expand=True, padx=20, pady=20)
+        self.main_tab = self.tabview.add("メイン")
+        self.settings_tab = self.tabview.add("設定")
+
+        # main tab widgets
+        self.status_label = ctk.CTkLabel(self.main_tab, text="ファイルを選択してください")
+        self.status_label.pack(pady=10)
+
+        self.upload_button = ctk.CTkButton(self.main_tab, text="ファイルを選択", command=self.load_excel_file)
+        self.upload_button.pack(pady=5)
+
+        self.column_combo = ctk.CTkComboBox(self.main_tab, values=[])
+        self.column_combo.pack(pady=5)
+
+        self.analyze_button = ctk.CTkButton(self.main_tab, text="分析開始", state="disabled", command=self.start_analysis)
+        self.analyze_button.pack(pady=5)
+
+        self.save_button = ctk.CTkButton(self.main_tab, text="結果を保存", state="disabled", command=self.save_results)
+        self.save_button.pack(pady=5)
+
+        self.progress_bar = ctk.CTkProgressBar(self.main_tab, width=400)
+        self.progress_bar.pack(pady=20)
+        self.progress_bar.set(0)
+
+        # settings tab widgets
+        param_frame = ctk.CTkFrame(self.settings_tab)
+        param_frame.pack(pady=10)
+
+        ctk.CTkLabel(param_frame, text="Temperature").grid(row=0, column=0, padx=10, pady=5)
+        self.temp_entry = ctk.CTkEntry(param_frame, width=60)
+        self.temp_entry.grid(row=0, column=1, padx=10)
+        self.temp_entry.insert(0, str(self.temperature))
+
+        ctk.CTkLabel(param_frame, text="Top-p").grid(row=0, column=2, padx=10)
+        self.top_p_entry = ctk.CTkEntry(param_frame, width=60)
+        self.top_p_entry.grid(row=0, column=3, padx=10)
+        self.top_p_entry.insert(0, str(self.top_p))
+
+        self.weight_frame = ctk.CTkFrame(self.settings_tab)
+        self.weight_frame.pack(pady=10, fill="x")
+        self.weight_sliders = {}
+        for i, (key, val) in enumerate(self.weights.items()):
+            ctk.CTkLabel(self.weight_frame, text=key).grid(row=i, column=0, sticky="w", padx=10, pady=5)
+            slider = ctk.CTkSlider(self.weight_frame, from_=0, to=2.0, number_of_steps=100)
+            slider.set(val)
+            slider.grid(row=i, column=1, padx=10, pady=5)
+            self.weight_sliders[key] = slider
+
+    def load_excel_file(self):
+        file_path = filedialog.askopenfilename(filetypes=[("Excel files", "*.xlsx")])
+        if not file_path:
+            return
+        try:
+            self.df = pd.read_excel(file_path, sheet_name=0)
+            self.column_combo.configure(values=list(self.df.columns))
+            if self.df.columns:
+                self.column_combo.set(self.df.columns[0])
+            self.status_label.configure(text=f"ファイルを読み込みました: {len(self.df)}件")
+            self.analyze_button.configure(state="normal")
+        except Exception as e:
+            self.status_label.configure(text="ファイルの読み込みに失敗", text_color="red")
+            messagebox.showerror("読み込みエラー", str(e))
+
+    def validate_parameters(self):
+        try:
+            self.temperature = float(self.temp_entry.get())
+            self.top_p = float(self.top_p_entry.get())
+            return True
+        except ValueError:
+            messagebox.showerror("エラー", "Temperature と Top-p には数値を入力してください")
+            return False
+
+    def start_analysis(self):
+        if not self.validate_parameters():
+            return
+        self.analyze_button.configure(state="disabled")
+        self.upload_button.configure(state="disabled")
+        threading.Thread(target=lambda: asyncio.run(self.analyze_file_async())).start()
+
+    async def analyze_file_async(self):
+        column = self.column_combo.get()
+        category_names = ["hate", "hate/threatening", "self-harm", "sexual",
+                          "sexual/minors", "violence", "violence/graphic"]
+        category_flags = {name: [] for name in category_names}
+        category_scores = {name: [] for name in category_names}
+        ag_scores = []
+        ag_reasons = []
+        total_rows = len(self.df)
+
+        for idx, row in self.df.iterrows():
+            text = row[column]
+            cats, scores = await self.analyzer.moderate_text(text)
+            for name in category_names:
+                category_flags[name].append(getattr(cats, name.replace("/", "_"), False))
+                category_scores[name].append(getattr(scores, name.replace("/", "_"), 0.0))
+            score, reason = await self.analyzer.get_aggressiveness_score(text, self.temperature, self.top_p)
+            ag_scores.append(score)
+            ag_reasons.append(reason)
+
+            progress = (idx + 1) / total_rows
+            self.progress_bar.set(progress)
+            self.status_label.configure(text=f"分析中... {idx + 1}/{total_rows}")
+
+        for name in category_names:
+            self.df[f"{name}_flag"] = category_flags[name]
+            self.df[f"{name}_score"] = category_scores[name]
+        self.df["aggressiveness_score"] = ag_scores
+        self.df["aggressiveness_reason"] = ag_reasons
+
+        weights = {k: slider.get() for k, slider in self.weight_sliders.items()}
+        self.config.data["weights"] = weights
+        self.config.save()
+        self.apply_total_score(weights)
+        self.status_label.configure(text="分析が完了しました", text_color="green")
+        self.save_button.configure(state="normal")
+        self.upload_button.configure(state="normal")
+        self.analyze_button.configure(state="normal")
+
+    def apply_total_score(self, weights):
+        def calc(row):
+            val = 0.0
+            val += weights.get("hate_score", 0) * row.get("hate_score", 0)
+            val += weights.get("hate/threatening_score", 0) * row.get("hate/threatening_score", 0)
+            val += weights.get("violence_score", 0) * row.get("violence_score", 0)
+            val += weights.get("sexual_score", 0) * row.get("sexual_score", 0)
+            val += weights.get("sexual/minors_score", 0) * row.get("sexual/minors_score", 0)
+            ag = row.get("aggressiveness_score") or 0
+            val += weights.get("aggressiveness_score", 0) * ag
+            val += weights.get("flag_hate", 0) * (1 if row.get("hate_flag") else 0)
+            val += weights.get("flag_hate/threatening", 0) * (1 if row.get("hate/threatening_flag") else 0)
+            val += weights.get("flag_violence", 0) * (1 if row.get("violence_flag") else 0)
+            val += weights.get("flag_sexual", 0) * (1 if row.get("sexual_flag") else 0)
+            return val
+
+        self.df["total_aggression"] = self.df.apply(calc, axis=1)
+
+    def save_results(self):
+        save_path = filedialog.asksaveasfilename(defaultextension=".xlsx", filetypes=[("Excel files", "*.xlsx")])
+        if not save_path:
+            return
+        try:
+            self.df.to_excel(save_path, index=False)
+            self.status_label.configure(text="結果を保存しました", text_color="green")
+        except Exception as e:
+            self.status_label.configure(text="保存に失敗しました", text_color="red")
+            messagebox.showerror("保存エラー", str(e))
+


### PR DESCRIPTION
## Summary
- add `config.py` with model name and persistent weights
- add `analyzer.py` to handle OpenAI calls and use few‑shot prompt
- add `ui.py` building a tabbed interface with dynamic column selection and weight sliders
- add `main.py` entry point
- update README with usage instructions

## Testing
- `python -m py_compile config.py analyzer.py ui.py main.py SNS用攻撃性判定.py`

------
https://chatgpt.com/codex/tasks/task_e_686cda0b6b2c8333b66714e01b367ab0