### PR TITLE
Fix default weight configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ This project provides a text moderation tool that evaluates the aggressiveness o
    python main.py
    ```
 
-The UI allows you to load an Excel file, select the column to analyze, and start moderation. You can adjust parameters and weight settings in the **設定** tab. Results can be saved back to an Excel file.
+The UI allows you to load an Excel file, select the column to analyze, and start moderation. You can adjust parameters and weight settings in the **設定** tab. Results can be saved back to an Excel file. Configuration values (including the weight settings) are saved to `config.json`. The default weights sum to `1.0`, so you can start analyzing without tweaking them first.

--- a/config.py
+++ b/config.py
@@ -5,16 +5,16 @@ CONFIG_FILE = 'config.json'
 MODEL_NAME = "gpt-4.1-mini-2025-04-14"
 
 DEFAULT_WEIGHTS = {
-    "hate_score": 0.5,
-    "hate/threatening_score": 0.3,
-    "violence_score": 0.3,
-    "sexual_score": 0.1,
-    "sexual/minors_score": 0.1,
-    "aggressiveness_score": 0.5,
-    "flag_hate": 2.0,
-    "flag_hate/threatening": 1.0,
-    "flag_violence": 1.5,
-    "flag_sexual": 1.0
+    "hate_score": 0.06,
+    "hate/threatening_score": 0.04,
+    "violence_score": 0.04,
+    "sexual_score": 0.02,
+    "sexual/minors_score": 0.02,
+    "aggressiveness_score": 0.06,
+    "flag_hate": 0.28,
+    "flag_hate/threatening": 0.14,
+    "flag_violence": 0.20,
+    "flag_sexual": 0.14
 }
 
 class ConfigManager:


### PR DESCRIPTION
## Summary
- scale `DEFAULT_WEIGHTS` so their sum is 1.0
- mention config persistence and default weights in the README

## Testing
- `python - <<'PY'
from config import ConfigManager
print('test load sum', sum(ConfigManager().data['weights'].values()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_686cf1b8aa588333924091345319d9cb