### PR TITLE
Persist parameter settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ This project provides a text moderation tool that evaluates the aggressiveness o
    python main.py
    ```
 
-The UI allows you to load an Excel file, select the column to analyze, and start moderation. You can adjust parameters and weight settings in the **設定** tab. Results can be saved back to an Excel file. Configuration values (including the weight settings) are saved to `config.json`. The default weights sum to `1.0`, so you can start analyzing without tweaking them first.
+The UI allows you to load an Excel file, select the column to analyze, and start moderation. You can adjust parameters and weight settings in the **設定** tab. Results can be saved back to an Excel file. Configuration values—including temperature, top-p, and the weight settings—are saved to `config.json`. The default weights sum to `1.0`, so you can start analyzing without tweaking them first.

--- a/config.py
+++ b/config.py
@@ -3,6 +3,8 @@ import os
 
 CONFIG_FILE = 'config.json'
 MODEL_NAME = "gpt-4.1-mini-2025-04-14"
+DEFAULT_TEMPERATURE = 1.0
+DEFAULT_TOP_P = 0.9
 
 DEFAULT_WEIGHTS = {
     "hate_score": 0.06,
@@ -32,7 +34,11 @@ class ConfigManager:
             with open(self.path, 'r', encoding='utf-8') as f:
                 self.data = json.load(f)
         else:
-            self.data = {"weights": DEFAULT_WEIGHTS.copy()}
+            self.data = {
+                "weights": DEFAULT_WEIGHTS.copy(),
+                "temperature": DEFAULT_TEMPERATURE,
+                "top_p": DEFAULT_TOP_P,
+            }
 
     def save(self):
         """Persist current settings to disk."""
@@ -48,3 +54,19 @@ class ConfigManager:
         if "weights" not in self.data:
             self.data["weights"] = {}
         self.data["weights"][key] = value
+
+    def get_temperature(self) -> float:
+        """Return the saved temperature setting."""
+        return float(self.data.get("temperature", DEFAULT_TEMPERATURE))
+
+    def set_temperature(self, value: float):
+        """Set and store the temperature value."""
+        self.data["temperature"] = value
+
+    def get_top_p(self) -> float:
+        """Return the saved top-p setting."""
+        return float(self.data.get("top_p", DEFAULT_TOP_P))
+
+    def set_top_p(self, value: float):
+        """Set and store the top-p value."""
+        self.data["top_p"] = value

--- a/ui.py
+++ b/ui.py
@@ -19,8 +19,8 @@ class ModerationApp(ctk.CTk):
         self.analyzer = analyzer
         self.config = config
         self.df = None
-        self.temperature = 1.0
-        self.top_p = 0.9
+        self.temperature = config.get_temperature()
+        self.top_p = config.get_top_p()
         self.weights = config.data.get("weights", {})
         self.updating_weights = False
         self.create_ui()
@@ -116,6 +116,8 @@ class ModerationApp(ctk.CTk):
         try:
             self.temperature = float(self.temp_entry.get())
             self.top_p = float(self.top_p_entry.get())
+            self.config.set_temperature(self.temperature)
+            self.config.set_top_p(self.top_p)
             return True
         except ValueError:
             messagebox.showerror("エラー", "数値を入力してください")
@@ -201,6 +203,8 @@ class ModerationApp(ctk.CTk):
 
         weights = {k: slider.get() for k, slider in self.weight_sliders.items()}
         self.config.data["weights"] = weights
+        self.config.set_temperature(self.temperature)
+        self.config.set_top_p(self.top_p)
         self.config.save()
         self.apply_total_score(weights)
         self.status_label.configure(text="分析が完了しました", text_color="green")


### PR DESCRIPTION
## Summary
- store `temperature` and `top_p` in the configuration file
- load saved temperature and top-p values on startup
- update config when running analysis
- document new config behavior in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile config.py ui.py analyzer.py main.py 'SNS用攻撃性判定.py'`

------
https://chatgpt.com/codex/tasks/task_e_686d112452608333a097f5caeb73b3b0